### PR TITLE
Add undoableIrreversibleCheckpoint flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ property set to `true` and `changeDetector` returns true.
 
 Reducers can optionally provide a `changeDetector` function to override what changes are allowed to be checkpointable.
 
+## Action flags
+
+Flags on actions can affect the behavior of the undo history state:
+- `undoableHistoryCheckpoint`: Marks when the next state should be considered a checkpoint in the undo history
+- `undoableIrreversableCheckpoint`: Marks when the next state should clear any undo history. Typically used if related
+state in another system (eg. a backend service) cannot be reversed.
+
 ## Example Usage
 
 Given a simple reducer that tracks the state of a string:

--- a/src/Undoable.js
+++ b/src/Undoable.js
@@ -86,16 +86,22 @@ export default function Undoable(reducers) {
 
 			// New states can only be pushed into the history if anything we care about actually changed.
 			if (anyChanged) {
-				if (action.undoableHistoryCheckpoint) {
+				if (action.undoableIrreversableCheckpoint) {
+					return {
+						past:    [nextState],  // irreversible checkpoints should clear out history
+						present: nextState,
+						future:  []            // clear the future state so we don't lose these new edits by a redo
+					};
+				} else if (action.undoableHistoryCheckpoint) {
 					return {
 						past:    state.past.concat([nextState]),
 						present: nextState,
-						future:  []  // clear the future state so we don't lose these new edits by a redo
+						future:  []            // clear the future state so we don't lose these new edits by a redo
 					};
 				} else {
 					return Object.assign({}, state, {
 						present: nextState,
-						future:  []  // clear the future state so we don't lose these new edits by a redo
+						future:  []            // clear the future state so we don't lose these new edits by a redo
 					});
 				}
 			} else {

--- a/test/Undoable.test.js
+++ b/test/Undoable.test.js
@@ -116,7 +116,7 @@ describe('Undoable', () => {
 
 			it('sets the present', () => expect(nextState.present).to.deep.equal({ test: 2 }));
 			it('keeps only the present state in the past', () => expect(nextState.past).to.deep.equal([{ test: 2 }]));
-			it('clears the feuture array', () => expect(nextState.future).to.be.empty);
+			it('clears the future array', () => expect(nextState.future).to.be.empty);
 		});
 	});
 

--- a/test/Undoable.test.js
+++ b/test/Undoable.test.js
@@ -101,6 +101,23 @@ describe('Undoable', () => {
 				});
 			});
 		});
+
+		context('when undoableIrreversableCheckpoint is true', () => {
+			let nextState;
+
+			beforeEach(() => {
+				const initialState = UndoableReducer({
+					past: [{ test: 0 }, { test: 1 }],
+					present: { test: 1 },
+					future: [{ something: true }]
+				}, {});
+				nextState = UndoableReducer(initialState, { type: TEST_ACTION, undoableIrreversableCheckpoint: true })
+			});
+
+			it('sets the present', () => expect(nextState.present).to.deep.equal({ test: 2 }));
+			it('keeps only the present state in the past', () => expect(nextState.past).to.deep.equal([{ test: 2 }]));
+			it('clears the feuture array', () => expect(nextState.future).to.be.empty);
+		});
 	});
 
 	describe('UNDO', () => {


### PR DESCRIPTION
Allows actions to clear out the undo history. Usage:

```js
store.dispatch({
  type: SOME_ACTION,
  undoableIrreversableCheckpoint: true
})
```